### PR TITLE
Feat: build docker images when a new release is created

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -7,13 +7,13 @@ on:
   release:
     types: [published]
 
-# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
+# Defines three custom environment variables for the workflow. These are used for the Container registry domain, and a name + version for the Docker image that this workflow builds.
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
   VERSION: ${{ github.sha }}
 
-# There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
+# There are two joba in this workflow. It's configured to run on the latest available version of Ubuntu.
 jobs:
   build-and-push-image-normal:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -10,7 +10,7 @@ on:
 # Defines environment variables for the workflow. These are used for the Container registry domain, and a version for the Docker image that this workflow builds.
 env:
   REGISTRY: ghcr.io
-  VERSION: ${{ github.sha }}
+  VERSION: ${{ github.ref_name }}
 
 jobs:
   build-and-push-image-gpu:

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -4,9 +4,8 @@ name: Create and publish a Docker image
 on:
   workflow_dispatch:
   
-  push:
-    branches:
-      - main
+  release:
+    types: [published]
 
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
 env:

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -1,0 +1,71 @@
+#
+name: Create and publish a Docker image
+
+on:
+  workflow_dispatch:
+  
+  push:
+    branches:
+      - main
+
+# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  VERSION: ${{ github.sha }}
+
+# There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
+jobs:
+  build-and-push-image-normal:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GH_PAT` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      #
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GH_PAT }}
+      - name: lowercase github.repository
+        run: |
+          echo "IMAGE_NAME=`echo ${{github.repository}} | tr '[:upper:]' '[:lower:]'`" >>${GITHUB_ENV}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }}
+  build-and-push-image-gpu:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GH_PAT` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      #
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GH_PAT }}
+      - name: lowercase github.repository
+        run: |
+          echo "IMAGE_NAME=`echo ${{github.repository}} | tr '[:upper:]' '[:lower:]'`" >>${GITHUB_ENV}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          Dockerfile: Dockerfile.gpu
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-gpu:${{ env.VERSION }}

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -36,6 +36,6 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: ./Dockerfile.gpu
+          file: ./Dockerfile-gpu
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }}

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -7,53 +7,24 @@ on:
   release:
     types: [published]
 
-# Defines three custom environment variables for the workflow. These are used for the Container registry domain, and a name + version for the Docker image that this workflow builds.
+# Defines environment variables for the workflow. These are used for the Container registry domain, and a version for the Docker image that this workflow builds.
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
   VERSION: ${{ github.sha }}
 
-# There are two joba in this workflow. It's configured to run on the latest available version of Ubuntu.
 jobs:
-  build-and-push-image-normal:
-    runs-on: ubuntu-latest
-    # Sets the permissions granted to the `GH_PAT` for the actions in this job.
-    permissions:
-      contents: read
-      packages: write
-      #
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
-      - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GH_PAT }}
-      - name: lowercase github.repository
-        run: |
-          echo "IMAGE_NAME=`echo ${{github.repository}} | tr '[:upper:]' '[:lower:]'`" >>${GITHUB_ENV}
-      - name: Build and push Docker image
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
-        with:
-          context: .
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }}
   build-and-push-image-gpu:
     runs-on: ubuntu-latest
     # Sets the permissions granted to the `GH_PAT` for the actions in this job.
     permissions:
       contents: read
       packages: write
-      #
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
       # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -62,9 +33,9 @@ jobs:
         run: |
           echo "IMAGE_NAME=`echo ${{github.repository}} | tr '[:upper:]' '[:lower:]'`" >>${GITHUB_ENV}
       - name: Build and push Docker image
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        uses: docker/build-push-action@v6
         with:
           context: .
-          Dockerfile: Dockerfile.gpu
+          file: ./Dockerfile.gpu
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-gpu:${{ env.VERSION }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }}


### PR DESCRIPTION
This PR adds a workflow that automatically creates the Docker image when a new release is created.

After merge you have to add a secret GH_PAT to the repository with the value of a personal access token with repo, write:packages and delete:packages scopes.

The first successful build will be private. You have to assign it manually to this repository and change the visibility of the package to public.

Address: 0x493FBf42777B6CE24B1c018c38D1A24C7572904F
