### PR TITLE
support for qwen2.5,llama 3.1,gemma-2,phi-3 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 torch>=1.13.1
 huggingface-hub>=0.24.7,<0.25
-transformers>=4.37.2
+transformers>=4.43.0
 datasets>=2.14.3
 accelerate>=0.27.2
 loguru==0.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 torch>=1.13.1
 huggingface-hub>=0.24.7,<0.25
-transformers>=4.43.0
+transformers>=4.43.0,<=4.44.2
 datasets>=2.14.3
 accelerate>=0.27.2
 loguru==0.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 torch>=1.13.1
 huggingface-hub>=0.24.7,<0.25
-transformers>=4.43.0,<=4.44.2
+transformers>=4.43.0,<=4.45.0
 datasets>=2.14.3
 accelerate>=0.27.2
 loguru==0.7.0

--- a/src/core/constant.py
+++ b/src/core/constant.py
@@ -23,6 +23,21 @@ SUPPORTED_BASE_MODELS = [
     "Qwen/Qwen2-7B-Instruct",
     "Qwen/Qwen2-72B",
     "Qwen/Qwen2-72B-Instruct",
+    # qwen2.5
+    "Qwen/Qwen2.5-0.5B",
+    "Qwen/Qwen2.5-0.5B-Instruct",
+    "Qwen/Qwen2.5-1.5B",
+    "Qwen/Qwen2.5-1.5B-Instruct",
+    "Qwen/Qwen2.5-3B",
+    "Qwen/Qwen2.5-3B-Instruct",
+    "Qwen/Qwen2.5-7B",
+    "Qwen/Qwen2.5-7B-Instruct",
+    "Qwen/Qwen2.5-14B",
+    "Qwen/Qwen2.5-14B-Instruct",
+    "Qwen/Qwen2.5-32B",
+    "Qwen/Qwen2.5-32B-Instruct",
+    "Qwen/Qwen2.5-72B",
+    "Qwen/Qwen2.5-72B-Instruct",
     # Yi
     "01-ai/Yi-6B",
     "01-ai/Yi-6B-Chat",
@@ -51,6 +66,13 @@ SUPPORTED_BASE_MODELS = [
     "google/gemma-7b",
     "google/gemma-2b-it",
     "google/gemma-7b-it",
+    # gemma2
+    "google/gemma-2-2b",
+    "google/gemma-2-9b",
+    "google/gemma-2-27b",
+    "google/gemma-2-2b-it",
+    "google/gemma-2-9b-it",
+    "google/gemma-2-27b-it",
     # zephyr
     "HuggingFaceH4/zephyr-7b-alpha",
     "HuggingFaceH4/zephyr-7b-beta",
@@ -66,4 +88,15 @@ SUPPORTED_BASE_MODELS = [
     "meta-llama/Meta-Llama-3-8B-Instruct",
     "meta-llama/Meta-Llama-3-70B",
     "meta-llama/Meta-Llama-3-70B-Instruct",
+    # llama3.1
+    "meta-llama/Meta-Llama-3.1-8B",
+    "meta-llama/Meta-Llama-3.1-8B-Instruct",
+    "meta-llama/Meta-Llama-3.1-70B",
+    "meta-llama/Meta-Llama-3.1-70B-Instruct",
+    # phi3
+    "microsoft/Phi-3.5-mini-instruct",
+    "microsoft/Phi-3.5-MoE-instruct",
+    "microsoft/Phi-3-mini-4k-instruct",
+    "microsoft/Phi-3-small-8k-instruct",
+    "microsoft/Phi-3-medium-4k-instruct",
 ]

--- a/src/core/constant.py
+++ b/src/core/constant.py
@@ -95,7 +95,6 @@ SUPPORTED_BASE_MODELS = [
     "meta-llama/Meta-Llama-3.1-70B-Instruct",
     # phi3
     "microsoft/Phi-3.5-mini-instruct",
-    "microsoft/Phi-3.5-MoE-instruct",
     "microsoft/Phi-3-mini-4k-instruct",
     "microsoft/Phi-3-small-8k-instruct",
     "microsoft/Phi-3-medium-4k-instruct",

--- a/src/core/template.py
+++ b/src/core/template.py
@@ -119,10 +119,10 @@ register_template(
 )
 
 register_template(
-    template_name='phi3',
+    template_name="phi3",
     system_format=None,
-    user_format='<|user|>\n{content}<|end|>\n<|assistant|>',
-    assistant_format='{content}<|end|>\n',
+    user_format="<|user|>\n{content}<|end|>\n<|assistant|>",
+    assistant_format="{content}<|end|>\n",
     system=None,
-    stop_word='<|end|>'
+    stop_word="<|end|>",
 )

--- a/src/core/template.py
+++ b/src/core/template.py
@@ -39,7 +39,7 @@ register_template(
 
 
 register_template(
-    template_name="qwen1.5",
+    template_name="qwen",
     system_format="<|im_start|>system\n{content}<|im_end|>\n",
     user_format="<|im_start|>user\n{content}<|im_end|>\n<|im_start|>assistant\n",
     assistant_format="{content}<|im_end|>\n",
@@ -116,4 +116,13 @@ register_template(
     assistant_format="{content}<|eot_id|>",
     system=None,
     stop_word="<|eot_id|>",
+)
+
+register_template(
+    template_name='phi3',
+    system_format=None,
+    user_format='<|user|>\n{content}<|end|>\n<|assistant|>',
+    assistant_format='{content}<|end|>\n',
+    system=None,
+    stop_word='<|end|>'
 )


### PR DESCRIPTION
support for qwen2.5, rename template name qwen1.5 to qwen. llama 3.1 for llama3,gemma-2 for gemma,phi-3 for phi3. update transformers version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the version of the `transformers` library to a more specific range, potentially enhancing compatibility and features.
- **New Features**
	- Expanded the list of available model identifiers, including new Qwen2.5, Gemma2, Llama3.1, and Phi3 models, enhancing user options for model selection.
	- Introduced a new template for user and assistant interactions, improving the formatting options for user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->