### PR TITLE
remove phi3-small-8k-instruct from the list of supported models

### DIFF
--- a/src/core/constant.py
+++ b/src/core/constant.py
@@ -96,6 +96,5 @@ SUPPORTED_BASE_MODELS = [
     # phi3
     "microsoft/Phi-3.5-mini-instruct",
     "microsoft/Phi-3-mini-4k-instruct",
-    "microsoft/Phi-3-small-8k-instruct",
     "microsoft/Phi-3-medium-4k-instruct",
 ]


### PR DESCRIPTION
Removing `microsoft/phi3-small-8k-instruct` from the list of supported models as it is not supported in the current setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed a base model from the supported models list, reducing available model selection options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->