### PR TITLE
chore: add deepseek distilled models to constant.py

### DIFF
--- a/src/core/constant.py
+++ b/src/core/constant.py
@@ -97,7 +97,7 @@ SUPPORTED_BASE_MODELS = [
     "microsoft/Phi-3.5-mini-instruct",
     "microsoft/Phi-3-mini-4k-instruct",
     "microsoft/Phi-3-medium-4k-instruct",
-    #deepseek
+    # deepseek
     "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B",
     "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B",
     "deepseek-ai/DeepSeek-R1-Distill-Llama-8B",

--- a/src/core/constant.py
+++ b/src/core/constant.py
@@ -97,4 +97,11 @@ SUPPORTED_BASE_MODELS = [
     "microsoft/Phi-3.5-mini-instruct",
     "microsoft/Phi-3-mini-4k-instruct",
     "microsoft/Phi-3-medium-4k-instruct",
+    #deepseek
+    "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B",
+    "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B",
+    "deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
+    "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B",
+    "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B",
+    "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
 ]


### PR DESCRIPTION
Add deepseek distilled models to `constant.py` to not auto-remove the models from cache

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for six new DeepSeek AI language models across various sizes, ranging from 1.5B to 70B parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->