### PR TITLE
feat: add support for phi4 and ministral 8b

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 torch>=1.13.1
-huggingface-hub>=0.24.7,<0.25
-transformers>=4.43.0,<=4.45.0
+huggingface-hub==0.29.1
+transformers==4.49.0
 datasets>=2.14.3
 accelerate>=0.27.2
 loguru==0.7.0

--- a/src/core/constant.py
+++ b/src/core/constant.py
@@ -97,7 +97,7 @@ SUPPORTED_BASE_MODELS = [
     "microsoft/Phi-3.5-mini-instruct",
     "microsoft/Phi-3-mini-4k-instruct",
     "microsoft/Phi-3-medium-4k-instruct",
-    #phi4
+    # phi4
     "microsoft/Phi-4-mini-instruct",
     "microsoft/phi-4",
     # deepseek

--- a/src/core/constant.py
+++ b/src/core/constant.py
@@ -97,6 +97,9 @@ SUPPORTED_BASE_MODELS = [
     "microsoft/Phi-3.5-mini-instruct",
     "microsoft/Phi-3-mini-4k-instruct",
     "microsoft/Phi-3-medium-4k-instruct",
+    #phi4
+    "microsoft/Phi-4-mini-instruct",
+    "microsoft/phi-4",
     # deepseek
     "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B",
     "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B",

--- a/src/core/constant.py
+++ b/src/core/constant.py
@@ -58,6 +58,7 @@ SUPPORTED_BASE_MODELS = [
     "mistralai/Mistral-7B-Instruct-v0.1",
     "mistralai/Mistral-7B-Instruct-v0.2",
     "mistralai/Mistral-7B-Instruct-v0.3",
+    "mistralai/Ministral-8B-Instruct-2410",
     # mixtral
     "mistralai/Mixtral-8x7B-v0.1",
     "mistralai/Mixtral-8x7B-Instruct-v0.1",

--- a/src/core/hf_utils.py
+++ b/src/core/hf_utils.py
@@ -1,5 +1,4 @@
 from huggingface_hub import HfApi
-from huggingface_hub.utils._errors import EntryNotFoundError
 from loguru import logger
 
 api = HfApi()
@@ -13,9 +12,12 @@ def download_lora_config(repo_id: str, revision: str) -> bool:
             local_dir="lora",
             revision=revision,
         )
-    except EntryNotFoundError:
-        logger.info("No adapter_config.json found in the repo, assuming full model")
-        return False
+    except Exception as e:
+        if "adapter_config.json" in str(e):
+            logger.info("No adapter_config.json found in the repo, assuming full model")
+            return False
+        else:
+            raise  # Re-raise the exception if it's not related to the missing file
     return True
 
 

--- a/src/core/template.py
+++ b/src/core/template.py
@@ -170,3 +170,15 @@ register_template(
     system=None,
     stop_word="<|end|>",
 )
+
+register_template(
+    template_name="phi4",
+    system_format=None,
+    user_format="<|user|>\n{content}<|end|>\n<|assistant|>",
+    assistant_format="{content}<|end|>\n",
+    tool_format="<|tool|>{content}<|/tool|>",
+    function_format= "<|tool_call|>{content}<|/tool_call|>",
+    observation_format="<|tool|>\n{content}<|end|>\n<|assistant|>",
+    system=None,
+    stop_word="<|end|>",
+)

--- a/src/core/template.py
+++ b/src/core/template.py
@@ -177,7 +177,7 @@ register_template(
     user_format="<|user|>\n{content}<|end|>\n<|assistant|>",
     assistant_format="{content}<|end|>\n",
     tool_format="<|tool|>{content}<|/tool|>",
-    function_format= "<|tool_call|>{content}<|/tool_call|>",
+    function_format="<|tool_call|>{content}<|/tool_call|>",
     observation_format="<|tool|>\n{content}<|end|>\n<|assistant|>",
     system=None,
     stop_word="<|end|>",


### PR DESCRIPTION
- Added support for the Phi4 template
- Updated `transformers` to version `4.49.0` to support partial rotary embeddings required for Phi4
- Removed import of `huggingface_hub.utils._errors` for compatibility with the updated version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated underlying dependency versions for improved consistency and stability.
- **New Features**
  - Expanded support to include new models: `"mistralai/Ministral-8B-Instruct-2410"`, `"microsoft/Phi-4-mini-instruct"`, and `"microsoft/phi-4"`.
- **Bug Fixes**
  - Enhanced exception handling in the configuration download process for better error management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->