### PR TITLE
fix(docker): upgrade to Ubuntu 22.04 to support transformers>=4.47.0

### DIFF
--- a/Dockerfile-gpu
+++ b/Dockerfile-gpu
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.3.1-runtime-ubuntu20.04
+FROM nvidia/cuda:11.8.0-runtime-ubuntu22.04
 
 RUN apt-get update && apt-get install -y \
     python3-dev \


### PR DESCRIPTION
Older Ubuntu base image used Python 3.8, which is incompatible with `transformers>=4.47.0`. Switched to `nvidia/cuda:11.8.0-runtime-ubuntu22.04`, which includes Python 3.10+ to resolve version mismatch during `pip install`.

Closes issue https://github.com/FLock-io/llm-loss-validator/issues/75

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Upgraded the GPU runtime environment by adopting newer versions of CUDA and Ubuntu for enhanced compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->