### PR TITLE
feat: add support for qwen3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 torch>=1.13.1
-huggingface-hub==0.29.1
-transformers==4.49.0
+huggingface-hub==0.30.0
+transformers==4.51.0
 datasets>=2.14.3
 accelerate>=0.27.2
 loguru==0.7.0

--- a/src/core/constant.py
+++ b/src/core/constant.py
@@ -38,6 +38,13 @@ SUPPORTED_BASE_MODELS = [
     "Qwen/Qwen2.5-32B-Instruct",
     "Qwen/Qwen2.5-72B",
     "Qwen/Qwen2.5-72B-Instruct",
+    #Qwen3
+    "Qwen/Qwen3-0.6B",
+    "Qwen/Qwen3-1.7B",
+    "Qwen/Qwen3-4B",
+    "Qwen/Qwen3-8B",
+    "Qwen/Qwen3-14B",
+    "Qwen/Qwen3-32B",
     # Yi
     "01-ai/Yi-6B",
     "01-ai/Yi-6B-Chat",

--- a/src/core/constant.py
+++ b/src/core/constant.py
@@ -38,7 +38,7 @@ SUPPORTED_BASE_MODELS = [
     "Qwen/Qwen2.5-32B-Instruct",
     "Qwen/Qwen2.5-72B",
     "Qwen/Qwen2.5-72B-Instruct",
-    #Qwen3
+    # Qwen3
     "Qwen/Qwen3-0.6B",
     "Qwen/Qwen3-1.7B",
     "Qwen/Qwen3-4B",

--- a/tests/test_validation.sh
+++ b/tests/test_validation.sh
@@ -10,6 +10,7 @@ pip install -r requirements.txt > /dev/null 2>&1
 
 declare -A MODEL_MAP=(
     ["Qwen/Qwen1.5-1.8B-Chat"]="qwen1.5"
+    ["Qwen/Qwen3-0.6B"]="qwen1.5"
     ["google/gemma-2b"]="gemma"
     ["microsoft/Phi-3-mini-4k-instruct"]="phi3"
     ["mistralai/Ministral-8B-Instruct-2410"]="mistral"
@@ -24,6 +25,7 @@ declare -A MODEL_MAP=(
 # Define models to validate - mix of full models and LORA
 MODELS=(
     "Qwen/Qwen1.5-1.8B-Chat"
+    "Qwen/Qwen3-0.6B"
     "google/gemma-2b"
     "microsoft/Phi-3-mini-4k-instruct"
     "mistralai/Ministral-8B-Instruct-2410"


### PR DESCRIPTION
- Update `transformers` and `huggingface-hub` dependency versions.
- Add Qwen3 model in tests.

Since Qwen3 uses the same chat template as Qwen2, no template update was necessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the new "Qwen3" group of models, including multiple sizes from 0.6B to 32B parameters.

- **Chores**
  - Updated dependencies to newer versions for improved compatibility and stability.
  - Included "Qwen/Qwen3-0.6B" in validation tests to ensure coverage for the new model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->